### PR TITLE
Fix README file structure and command formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ Download the Linux ZIP from the latest release
 Extract the ZIP
 
 Give the binary executable permission:
-
+```bash
 chmod +x notes-linux
-
+```
 
 Run the app:
-
+```bash
 ./notes-linux
+```
 
 🔄 Auto-Update System
 
@@ -51,7 +52,7 @@ Run the app:
 Works for both Windows (.exe) and Linux binaries.
 
 📂 File Structure
-Notes App ZIP/
+.
 ├── notes-win.exe       # Windows binary
 ├── notes-linux         # Linux binary
 └── README.md           # This file


### PR DESCRIPTION
The file structure in the README.md has been updated to accurately reflect the repository's contents.

The `chmod` and run commands for Linux have been placed in markdown code blocks for better readability and to make them easier to copy and paste.